### PR TITLE
Fix tests

### DIFF
--- a/respy/data.py
+++ b/respy/data.py
@@ -33,11 +33,11 @@ def create_kw_97(params, options):
     optim_paras, options = process_params_and_options(params, options)
 
     dtypes = {
-        "Identifier": np.int,
-        "Age": np.int,
+        "Identifier": int,
+        "Age": int,
         "Experience_School": np.uint8,
         "Choice": "category",
-        "Wage": np.float,
+        "Wage": float,
     }
 
     df = pd.read_csv(

--- a/respy/tests/test_randomness.py
+++ b/respy/tests/test_randomness.py
@@ -29,7 +29,9 @@ def test_invariance_of_model_solution_in_solve_and_criterion_functions(model):
     state_space_crit = log_like.keywords["solve"].keywords["state_space"]
 
     for state_space_ in [state_space_sim, state_space_crit]:
-        assert state_space.core.equals(state_space_.core.reindex_like(state_space.core))
+        #assert state_space.core.equals(state_space_.core.reindex_like(state_space.core))  
+        for k in state_space.core.core:
+            assert all(state_space.core.core[k] == state_space_.core.core[k])
 
         apply_to_attributes_of_two_state_spaces(
             state_space.wages, state_space_.wages, np.testing.assert_array_equal,


### PR DESCRIPTION
Comments: 
- 13 of the 28 marked tests are now passing
- `test_regression.py`: Couldn't solve this one yet, but it only seems to be the models with observables, so it is probably a good idea to take a closer look at those. Tests for models without observables are passing.
- `test_solve.py` (done): In two of the three tests, the problem was that the function `_create_core_period_choice` alters the core in place. Changing the order of some commands resolved this, but maybe we should still look into whether that is supposed to be happening.
- `test_randomness.py` (done): Problem was just that the core isn't a pandas.DataFrame anymore. I implemented a solution for the dictionary case which is passing. Could be more elegant though.
- 
